### PR TITLE
 Remove redundant build flags

### DIFF
--- a/org.gnome.Contacts.yml
+++ b/org.gnome.Contacts.yml
@@ -36,10 +36,6 @@ finish-args:
   - --talk-name=ca.desrt.dconf
   - --env=DCONF_USER_CONFIG_DIR=.config/dconf
 
-build-options:
-  cflags: -O2 -g
-  cxxflags: -O2 -g
-
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.