### PR TITLE
Update to 42.0

### DIFF
--- a/org.gnome.Contacts.yml
+++ b/org.gnome.Contacts.yml
@@ -1,7 +1,7 @@
 app-id: org.gnome.Contacts
 
 runtime: org.gnome.Platform
-runtime-version: '41'
+runtime-version: '42'
 sdk: org.gnome.Sdk
 
 command: gnome-contacts
@@ -57,8 +57,8 @@ modules:
       - --disable-backend
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gnome-online-accounts/3.40/gnome-online-accounts-3.40.0.tar.xz
-        sha256: 585c4f979f6f543b77bfdb4fb01eb18ba25c2aec5b7866c676d929616fb2c3fa
+        url: https://download.gnome.org/sources/gnome-online-accounts/3.40/gnome-online-accounts-3.40.1.tar.xz
+        sha256: 955a03128d0e87855d34d7c534e088f6286ed7ac01baa4ef824ef42a2cb39aad
         x-checker-data:
           type: gnome
           name: gnome-online-accounts
@@ -77,14 +77,12 @@ modules:
       - -DICAL_BUILD_DOCS=false
     sources:
       - type: archive
-        url: https://github.com/libical/libical/releases/download/v3.0.10/libical-3.0.10.tar.gz
-        sha256: f933b3e6cf9d56a35bb5625e8e4a9c3a50239a85aea05ed842932c1a1dc336b4
+        url: https://github.com/libical/libical/releases/download/v3.0.14/libical-3.0.14.tar.gz
+        sha256: 4284b780356f1dc6a01f16083e7b836e63d3815e27ed0eaaad684712357ccc8f
         x-checker-data:
           type: anitya
           project-id: 1637
           url-template: https://github.com/libical/libical/releases/download/v$version/libical-$version.tar.gz
-
-  - shared-modules/libcanberra/libcanberra.json
 
   - name: evolution-data-server
     cleanup:
@@ -108,11 +106,12 @@ modules:
       - -DENABLE_INSTALLED_TESTS=OFF
       - -DENABLE_GTK_DOC=OFF
       - -DENABLE_EXAMPLES=OFF
+      - -DENABLE_CANBERRA=OFF
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/evolution-data-server/3.42/evolution-data-server-3.42.0.tar.xz
-        sha256: e8fdd3bc47a07d6f8a3052bbcae880f20f6dbc4f6973a8e90d00169bb99b1635
+        url: https://download.gnome.org/sources/evolution-data-server/3.44/evolution-data-server-3.44.0.tar.xz
+        sha256: 0d8881b5c51e1b91761b1945db264a46aabf54a73eea1ca8f448b207815d582e
         x-checker-data:
           type: gnome
           name: evolution-data-server
@@ -131,42 +130,21 @@ modules:
       - /share/GConf
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/folks/0.15/folks-0.15.3.tar.xz
-        sha256: 21d737faf093f4be065473ee70ca20885b9a2c3685941dba24c2239fd3c544a5
+        url: https://download.gnome.org/sources/folks/0.15/folks-0.15.5.tar.xz
+        sha256: 0fff8a896330cd82aee4598324f7e541c884d0337536212723b4beb38c759086
         x-checker-data:
           type: gnome
           name: folks
 
-  - name: gnome-desktop
+  - name: libportal
     buildsystem: meson
     config-opts:
-      - -Ddebug-tools=false
-      - -Dudev=disabled
-      - -Dgtk_doc=false
-      - -Ddesktop_docs=false
+      - -Ddocs=false
+      - -Dbackends=gtk4
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gnome-desktop/41/gnome-desktop-41.0.tar.xz
-        sha256: 69cb1d3d9a10700eb66348ef1c0e66a855fc5a97ae62902df97a499da11562d2
-        x-checker-data:
-          type: gnome
-          name: gnome-desktop
-
-  - name: cheese
-    buildsystem: meson
-    config-opts:
-      - -Dgtk_doc=false
-      - -Dintrospection=true
-      - -Dman=false
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/cheese.git
-        tag: '41.0'
-        commit: 92ef18589eb10fab08f0806846c66d1e1383c78d
-        x-checker-data:
-         type: git
-         url: https://gitlab.gnome.org/GNOME/cheese.git
-         tag-pattern: ^([\d.]+)$
+        url: https://github.com/flatpak/libportal/releases/download/0.6/libportal-0.6.tar.xz
+        sha256: 88a12c3ba71bc31acff7238c280de697d609cebc50830c3766776ec35abc6566
 
   - name: gnome-contacts
     buildsystem: meson
@@ -175,9 +153,9 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/gnome-contacts.git
-        tag: '41.0'
-        commit: 06d6cd077014164d820a35d4f10d890b25572ab1
+        tag: '42.0'
+        commit: 06fd6bf78baa1717290af02160cc6db4d19ad075
         x-checker-data:
-         type: git
-         url: https://gitlab.gnome.org/GNOME/gnome-contacts.git
-         tag-pattern: ^([\d.]+)$
+          type: git
+          url: https://gitlab.gnome.org/GNOME/gnome-contacts.git
+          tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
Update gnome-online-accounts-3.40.0.tar.xz to 3.40.1
Update libical-3.0.10.tar.gz to 3.0.14
Update evolution-data-server-3.42.0.tar.xz to 3.44.0
Update folks-0.15.3.tar.xz to 0.14.0
Update gnome-desktop-41.0.tar.xz to 42.0
Update cheese.git to 41.1
Update gnome-contacts.git to 42.0

Based on https://github.com/flathub/org.gnome.Contacts/pull/54