### PR TITLE
x-checker-data: Don't use 3.x versioning

### DIFF
--- a/org.gnome.Contacts.yml
+++ b/org.gnome.Contacts.yml
@@ -54,6 +54,7 @@ modules:
         x-checker-data:
           type: gnome
           name: rest
+          stable-only: false
 
   - name: gnome-online-accounts
     buildsystem: meson
@@ -139,6 +140,7 @@ modules:
         x-checker-data:
           type: gnome
           name: folks
+          stable-only: false
 
   - name: libportal
     buildsystem: meson


### PR DESCRIPTION
These modules don't follow the rule that for version older than 42.0, x.odd.z are unstable releases.