### PR TITLE
fix: add ro file access to contact photos

### DIFF
--- a/org.gnome.Contacts.yml
+++ b/org.gnome.Contacts.yml
@@ -33,6 +33,7 @@ finish-args:
   - --filesystem=xdg-data/pixmaps/faces:create
   # Access for evolution-data-server avatars
   - --filesystem=xdg-cache/evolution/addressbook:ro
+  - --filesystem=xdg-data/evolution/addressbook/system/photos:ro
   # Needed for dconf to work
   - --metadata=X-DConf=migrate-path=/org/gnome/Contacts/
 


### PR DESCRIPTION
Currently, you can only pick photos. Closing GNOME Contacts, and re-opening the contact edited before shows no image. Allowing read access to the EDS photo location, show the desired image.